### PR TITLE
comment syntax: use [major] instead of #major because git thinks # is a comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ The process, in detail:
  - If that tag is pointing to this commit, do nothing
  - Otherwise, figure out the next version by looking at the _first line_ of all commits between the last version and the current commit:
    - figure out the bump strategy:
-     - extract any instances of `#(major|minor|patch)(-release)?` (i.e. `#major`, `#minor`, `#patch`, `#major-release`, etc)
+     - extract any instances of `[(major|minor|patch)(-release)?]` (i.e. `[major]`, `[minor]`, `[patch]`, `[major-release]`, etc)
      - use the highest one found
      - if no explicit bump is found, use` defaultBump` (defaults to `minor`)
    - if the bump strategy is greater than `maxBump` (default unset), fail (this can be used to ensure a version branch only makes patch releases)
    - if the bump strategy is greater than `minBump` (default unset), use `minBump` instead (conversely used to ensure all new `master` commits create minor versions instead of patch releases)
    - apply the bump to make a new version:
      - if `releaseTrigger` is `auto`, a new release is always made
-     - if `releaseTrigger` is `commit`, a new release is only made if the commit message contains `#release` (or `#major-release`, `#minor-release`, `#patch-release`)
+     - if `releaseTrigger` is `commit`, a new release is only made if the commit message contains `[release]` (or `[major-release]`, `[minor-release]`, `[patch-release]`)
  - tag it (if `doTag`, default `true`)
  - push it (if `doPush`, default `true` except for Pull Requests)
 

--- a/test.js
+++ b/test.js
@@ -1,1 +1,3 @@
+#!/usr/bin/env node
 require('./lib.js').test()
+console.log("OK")


### PR DESCRIPTION
Technically this is a breaking change, but nobody much has used the `#` syntax and it's fraught so I figure we just merge this into v1.